### PR TITLE
Fix window display on secondary monitor

### DIFF
--- a/tomb3/specific/winmain.cpp
+++ b/tomb3/specific/winmain.cpp
@@ -286,7 +286,7 @@ LRESULT CALLBACK WinAppProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 #ifdef TROYESTUFF
 	case WM_MOVE:
-		DXMove(LOWORD(lParam), HIWORD(lParam));
+		DXMove((short)LOWORD(lParam), (short)HIWORD(lParam));
 		break;
 #endif
 	}


### PR DESCRIPTION
Same fix as the one I did for the Tomb4 project: adds explicit casting to fix a bug with the window not rendering when moved to a secondary monitor.